### PR TITLE
Update README title to "Microsoft · GitHub Foundations"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GitHub Foundations Microsoft Certification
+# Microsoft · GitHub Foundations
 
 📘 Repository focused on practicing code versioning with Git and GitHub, following the guidelines of the GitHub Foundations course by Microsoft Learn.
 


### PR DESCRIPTION
- Changed the title of the README from "GitHub Foundations Microsoft Certification" to "Microsoft · GitHub Foundations".
- This update better reflects the content and focus of the repository.